### PR TITLE
Export path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 # Export environment variables only if the ".env" file exists.
 [ -f .env ] && export $(grep -v '^#' .env | xargs)
 export DEBUG=False
+export PATH="$HOME/.local/bin:$PATH"
 
 uv run manage.py collectstatic --no-input
 uv run manage.py migrate


### PR DESCRIPTION
This change must fix the following error on Render:
```
downloading uv 0.7.12 x86_64-unknown-linux-gnu
no checksums to verify
installing to /opt/render/.local/bin
  uv
  uvx
everything's installed!
To add $HOME/.local/bin to your PATH, either restart your shell or run:
    source $HOME/.local/bin/env (sh, bash, zsh)
    source $HOME/.local/bin/env.fish (fish)
./build.sh: line 14: uv: command not found
==> Build failed 😞
```